### PR TITLE
Produce more builds in GitHub Actions

### DIFF
--- a/.github/workflows/build-rolling.yml
+++ b/.github/workflows/build-rolling.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal -c Release
     - name: Generate generic release
-      run: dotnet publish --no-build -c Release
+      run: dotnet publish --no-build -c Release --self-contained false
     - name: Upload generic release
       uses: actions/upload-artifact@v2.2.4
       with:

--- a/.github/workflows/build-rolling.yml
+++ b/.github/workflows/build-rolling.yml
@@ -23,10 +23,38 @@ jobs:
       run: dotnet build --no-restore -c Release
     - name: Test
       run: dotnet test --no-build --verbosity normal -c Release
-    - name: Generate release
+    - name: Generate generic release
       run: dotnet publish --no-build -c Release
-    - name: Upload artifact
+    - name: Upload generic release
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: NTypeWriterCLI-Rolling-Release
+        name: NTypewriterCLI-Rolling-Release-Generic
         path: NTypeWriterCli/bin/Release/netcoreapp3.1/publish
+    - name: Generate Windows release
+      run: dotnet publish -c Release -r win10-x64
+    - name: Upload Windows release
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: NTypewriterCLI-Rolling-Release-Windows-x64
+        path: NTypeWriterCli/bin/Release/netcoreapp3.1/win10-x64/publish
+    - name: Generate Linux x64 release
+      run: dotnet publish -c Release -r linux-x64
+    - name: Upload Linux x64 release
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: NTypewriterCLI-Rolling-Release-Linux-x64
+        path: NTypeWriterCli/bin/Release/netcoreapp3.1/linux-x64/publish
+    - name: Generate Linux ARM64 release
+      run: dotnet publish -c Release -r linux-arm64
+    - name: Upload Linux ARM64 release
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: NTypewriterCLI-Rolling-Release-Linux-ARM64
+        path: NTypeWriterCli/bin/Release/netcoreapp3.1/linux-arm64/publish
+    - name: Generate Linux musl x64 release
+      run: dotnet publish -c Release -r linux-musl-x64
+    - name: Upload Linux musl x64 release
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: NTypewriterCLI-Rolling-Release-Linux-musl-x64
+        path: NTypeWriterCli/bin/Release/netcoreapp3.1/linux-musl-x64/publish


### PR DESCRIPTION
Generic build relies on an installed .NET 5, but works on all platforms. Besides that I added a few combinations of OS, library, and CPU architecture.